### PR TITLE
Use explicit UTF-8 decode in clean_text

### DIFF
--- a/ML_StageColumn.py
+++ b/ML_StageColumn.py
@@ -37,7 +37,7 @@ def detect_encoding(file_path):
 def clean_text(text):
     """Handle all encoding issues"""
     if not isinstance(text, str):
-        text = str(text, errors='replace')
+        text = text.decode('utf-8', errors='replace')
     return text.encode('latin1', 'ignore').decode('latin1', errors='replace').strip()
 
 def vectorize(txt, target, ngram, vectorizer=None, selector=None):


### PR DESCRIPTION
## Summary
- Explicitly decode non-str text with UTF-8 before existing Latin-1 normalization in `clean_text`

## Testing
- `python -m py_compile ML_StageColumn.py`


------
https://chatgpt.com/codex/tasks/task_e_68bee85c1ba08326b8cf2725a40c842d